### PR TITLE
Unblock all window events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "darksoulsiii-practice-tool"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "const_format",
  "embed-resource",
@@ -483,7 +483,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libds3"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "log",
  "macro-param",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "macro-param"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -570,7 +570,7 @@ checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
 
 [[package]]
 name = "no-logo"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libds3",
  "once_cell",
@@ -623,7 +623,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "param-mod"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "libds3",
  "once_cell",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "param-tinkerer"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "hudhook",
  "imgui",
@@ -1004,7 +1004,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scripts"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "hudhook",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Andrea Venuta <venutawebdesign@gmail.com>"]
 
 [profile.dev]

--- a/jdsd_dsiii_practice_tool.toml
+++ b/jdsd_dsiii_practice_tool.toml
@@ -45,4 +45,4 @@ log_level = "DEBUG"
 display = "0"
 hide = "rshift+0"
 show_console = false
-indicators = ["game_version", "igt"]
+indicators = ["game_version", "igt", "fps"]

--- a/practice-tool/src/main.rs
+++ b/practice-tool/src/main.rs
@@ -79,6 +79,10 @@ fn main() {
     match get_latest_version() {
         Ok((latest_version, download_url, release_notes)) => {
             if latest_version > current_version {
+                let release_notes = match release_notes.find("## What's Changed") {
+                    Some(i) => release_notes[..i].trim(),
+                    None => &release_notes,
+                };
                 let update_msg = format!(
                     "A new version of the practice tool is available!\n\nLatest version: \
                      {}\nInstalled version: {}\n\nRelease notes:\n{}\n\nDo you want to download \

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -505,14 +505,6 @@ impl ImguiRenderLoop for PracticeTool {
             }]),
         });
     }
-
-    fn should_block_messages(&self, _: &Io) -> bool {
-        match &self.ui_state {
-            UiState::MenuOpen => true,
-            UiState::Closed => false,
-            UiState::Hidden => false,
-        }
-    }
 }
 
 // Display some imgui debug information. Very expensive.


### PR DESCRIPTION
This PR unblocks all window events, as none of them actually deal with the game's input and are only annoying as they block important functionality (fullscreen, close the game, minimize/unminimize) when the menu is open.

Closes #64.