### PR TITLE
XInput deadzone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Andrea Venuta <venutawebdesign@gmail.com>"]
 
 [profile.dev]
@@ -46,6 +46,7 @@ features = [
   "Win32_System_SystemInformation",
   "Win32_System_SystemServices",
   "Win32_System_Threading",
+  "Win32_UI_Input_XboxController", 
 ]
 
 # [patch.'crates-io']

--- a/practice-tool/src/config.rs
+++ b/practice-tool/src/config.rs
@@ -283,7 +283,7 @@ impl TryFrom<String> for FlagSpec {
             "ik_foot_ray" => Ok(FlagSpec::new("IK foot ray", |c| &c.ik_foot_ray)),
             "debug_sphere_1" => Ok(FlagSpec::new("Debug sphere 1", |c| &c.debug_sphere_1)),
             "debug_sphere_2" => Ok(FlagSpec::new("Debug sphere 2", |c| &c.debug_sphere_2)),
-            "gravity" => Ok(FlagSpec::new("Gravity", |c| &c.gravity)),
+            "gravity" => Ok(FlagSpec::new("No Gravity", |c| &c.gravity)),
             e => Err(format!("\"{}\" is not a valid flag specifier", e)),
         }
     }


### PR DESCRIPTION
This PR adds a synthetic, small deadzone to deal with the age-old FKS jump problem. This should work regardless if Steam Input is used, and especially works around [this Wine regression](https://gitlab.winehq.org/wine/wine/-/commit/7fd8ae1e4f0f44f58745119d35ac3c1fd231780b) that sets vertical axes to -1 when the sticks are idle.

Also closes #62.