### PR TITLE
Add basic frame counter + additional speed modifier options

### DIFF
--- a/jdsd_dsiii_practice_tool.toml
+++ b/jdsd_dsiii_practice_tool.toml
@@ -2,7 +2,7 @@ commands = [
   { savefile_manager = "ctrl+o" },
   { item_spawner = "ctrl+u" },
   { character_stats = true },
-  { cycle_speed = [1, 3], hotkey = "8" },
+  { cycle_speed = [0.5, 1.0, 2.0, 5.0], hotkey = "8" },
   { souls = 10000, hotkey = "9" },
   { open_menu = "travel" },
   { open_menu = "attune" },

--- a/practice-tool/src/config.rs
+++ b/practice-tool/src/config.rs
@@ -44,6 +44,7 @@ pub(crate) enum Indicator {
     GameVersion,
     ImguiDebug,
     Fps,
+    FrameCount,
 }
 
 impl Indicator {
@@ -62,6 +63,7 @@ impl TryFrom<String> for Indicator {
             "game_version" => Ok(Indicator::GameVersion),
             "imgui_debug" => Ok(Indicator::ImguiDebug),
             "fps" => Ok(Indicator::Fps),
+            "framecount" => Ok(Indicator::FrameCount),
             value => Err(format!("Unrecognized indicator: {value}")),
         }
     }

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -50,6 +50,9 @@ pub(crate) struct PracticeTool {
     position_bufs: [String; 4],
     igt_buf: String,
     fps_buf: String,
+
+    framecount: u32,
+    framecount_buf: String,
 }
 
 impl PracticeTool {
@@ -175,6 +178,8 @@ impl PracticeTool {
             position_bufs: Default::default(),
             igt_buf: Default::default(),
             fps_buf: Default::default(),
+            framecount: 0,
+            framecount_buf: Default::default(),
         }
     }
 
@@ -351,6 +356,12 @@ impl PracticeTool {
                                 write!(self.fps_buf, "FPS {fps}",).ok();
                                 ui.text(&self.fps_buf);
                             }
+                        },
+                        Indicator::FrameCount => {
+                            self.framecount_buf.clear();
+                            write!(self.framecount_buf, "Frame count {0}", self.framecount,).ok();
+                            ui.text(&self.framecount_buf);
+                            self.framecount += 1;
                         },
                         Indicator::ImguiDebug => {
                             imgui_debug(ui);


### PR DESCRIPTION
This PR adds the following:
- Additional speed modifier options by default, changing the previous toggle between x1.0 and x3.0 to cycling through x0.5, x1.0, x2.0 and x5.0. This is to get finer controls, as well as have one slow-down option for testing. This is just a config edit, so it can still be changed to whatever users prefer.
- Basic frame counter, starting at 0 when the practice tool starts and incrementing by 1 every frame/update. This is simply to have a reliable frame reference for recordings when testing and glitch hunting, in order to make it easier to reproduce potential setups in them. I plan to expand this feature slightly in the future, either by finding a game-internal value that keeps track of it from game start and/or by adding a "reset to 0" button, however for now this should serve its purpose just fine.