### PR TITLE
Add "no collision" flag.

### DIFF
--- a/jdsd_dsiii_practice_tool.toml
+++ b/jdsd_dsiii_practice_tool.toml
@@ -40,7 +40,8 @@ commands = [
   { target = "ctrl+n" },
   { flag = "ai_disable", hotkey = "f1" },
   { flag = "gravity", hotkey = "f2" },
-  { flag = "evt_disable", hotkey = "f3" },
+  { flag = "collision", hotkey = "f3" },
+  { flag = "evt_disable", hotkey = "f9" },
   { quitout = "p" }
 ]
 

--- a/lib/libds3/src/pointers.rs
+++ b/lib/libds3/src/pointers.rs
@@ -64,6 +64,7 @@ pub struct PointerChains {
     pub debug_sphere_1: Bitflag<u8>,
     pub debug_sphere_2: Bitflag<u8>,
     pub gravity: Bitflag<u8>,
+    pub collision: Bitflag<u8>,
     pub speed: PointerChain<f32>,
     pub position: (PointerChain<f32>, PointerChain<[f32; 3]>),
     pub character_stats: PointerChain<CharacterStats>,
@@ -301,6 +302,7 @@ impl From<BaseAddresses> for PointerChains {
             debug_sphere_1: bitflag!(0b1; base_hbd, 0x30),
             debug_sphere_2: bitflag!(0b1; base_hbd, 0x31),
             gravity: bitflag!(0b1000000; world_chr_man, 0x80, 0x1a08),
+            collision: bitflag!(0b1; world_chr_man, 0x40, 0x0, 0x50, 0x187),
             speed: pointer_chain!(world_chr_man, 0x80, xa as _, 0x28, offs_speed as _),
             position: (
                 pointer_chain!(world_chr_man, 0x40, 0x28, 0x74),

--- a/practice-tool/src/config.rs
+++ b/practice-tool/src/config.rs
@@ -328,6 +328,7 @@ impl TryFrom<String> for FlagSpec {
             "debug_sphere_1" => Ok(FlagSpec::new("Debug sphere 1", |c| &c.debug_sphere_1)),
             "debug_sphere_2" => Ok(FlagSpec::new("Debug sphere 2", |c| &c.debug_sphere_2)),
             "gravity" => Ok(FlagSpec::new("No Gravity", |c| &c.gravity)),
+            "collision" => Ok(FlagSpec::new("No Collision", |c| &c.collision)),
             e => Err(format!("\"{}\" is not a valid flag specifier", e)),
         }
     }


### PR DESCRIPTION
This adds a "no collision" flag.

The usual one found in the games debug menu seems to be a bit janky in this game, so I found this other one via the "debug dash" feature of the debug menu (no-clip). From what I can tell, it works well and as expected.

I also gave it the f3 hotkey, which was previously used by "evt_disable". I feel like it makes more sense to have "no gravity" and "no collision" next to eachother. I set "evt_disable" to f9 for now, although maybe it's worth thinking about shifting all the render f* hotkeys over to start at f5, so evt_disable can be f4?

Tested and working on: 1.03, 1.04, 1.05, 1.06, 1.08, 1.13, 1.15 and 1.15.2.