### PR TITLE
Add velocity indicator.

### DIFF
--- a/jdsd_dsiii_practice_tool.toml
+++ b/jdsd_dsiii_practice_tool.toml
@@ -53,9 +53,9 @@ show_console = false
 indicators = [
   { indicator = "game_version", enabled = true },
   { indicator = "igt", enabled = true },
-  { indicator = "position", enabled = true },
-  { indicator = "animation", enabled = true },
-  { indicator = "fps", enabled = true },
-  { indicator = "framecount", enabled = true },
+  { indicator = "position", enabled = false },
+  { indicator = "animation", enabled = false },
+  { indicator = "fps", enabled = false },
+  { indicator = "framecount", enabled = false },
   { indicator = "imgui_debug", enabled = false }
 ]

--- a/jdsd_dsiii_practice_tool.toml
+++ b/jdsd_dsiii_practice_tool.toml
@@ -54,6 +54,7 @@ indicators = [
   { indicator = "game_version", enabled = true },
   { indicator = "igt", enabled = true },
   { indicator = "position", enabled = false },
+  { indicator = "position_change", enabled = false },
   { indicator = "animation", enabled = false },
   { indicator = "fps", enabled = false },
   { indicator = "framecount", enabled = false },

--- a/practice-tool/src/config.rs
+++ b/practice-tool/src/config.rs
@@ -41,6 +41,7 @@ pub(crate) struct Settings {
 pub(crate) enum IndicatorType {
     Igt,
     Position,
+    PositionChange,
     GameVersion,
     ImguiDebug,
     Fps,
@@ -61,6 +62,7 @@ impl Indicator {
             Indicator { indicator: IndicatorType::GameVersion, enabled: true },
             Indicator { indicator: IndicatorType::Igt, enabled: true },
             Indicator { indicator: IndicatorType::Position, enabled: false },
+            Indicator { indicator: IndicatorType::PositionChange, enabled: false },
             Indicator { indicator: IndicatorType::Animation, enabled: false },
             Indicator { indicator: IndicatorType::Fps, enabled: false },
             Indicator { indicator: IndicatorType::FrameCount, enabled: false },
@@ -84,6 +86,10 @@ impl TryFrom<IndicatorConfig> for Indicator {
             "position" => {
                 Ok(Indicator { indicator: IndicatorType::Position, enabled: indicator.enabled })
             },
+            "position_change" => Ok(Indicator {
+                indicator: IndicatorType::PositionChange,
+                enabled: indicator.enabled,
+            }),
             "game_version" => {
                 Ok(Indicator { indicator: IndicatorType::GameVersion, enabled: indicator.enabled })
             },

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -394,10 +394,10 @@ impl PracticeTool {
                                 (self.pointers.position.1.read(), self.pointers.position.0.read())
                             {
                                 self.position_bufs.iter_mut().for_each(String::clear);
-                                write!(self.position_bufs[0], "{x:.2}").ok();
-                                write!(self.position_bufs[1], "{y:.2}").ok();
-                                write!(self.position_bufs[2], "{z:.2}").ok();
-                                write!(self.position_bufs[3], "{a:.2}").ok();
+                                write!(self.position_bufs[0], "{x:.3}").ok();
+                                write!(self.position_bufs[1], "{y:.3}").ok();
+                                write!(self.position_bufs[2], "{z:.3}").ok();
+                                write!(self.position_bufs[3], "{a:.3}").ok();
 
                                 ui.text_colored(
                                     [0.7048, 0.1228, 0.1734, 1.],

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -48,6 +48,9 @@ pub(crate) struct PracticeTool {
     fonts: Option<FontIDs>,
 
     position_bufs: [String; 4],
+    position_prev: [f32; 3],
+    position_change_buf: String,
+
     igt_buf: String,
     fps_buf: String,
 
@@ -177,7 +180,9 @@ impl PracticeTool {
             log_tx,
             fonts: None,
             ui_state: UiState::Closed,
+            position_prev: Default::default(),
             position_bufs: Default::default(),
+            position_change_buf: Default::default(),
             igt_buf: Default::default(),
             fps_buf: Default::default(),
             framecount: 0,
@@ -278,6 +283,7 @@ impl PracticeTool {
                             let label = match indicator.indicator {
                                 IndicatorType::GameVersion => "Game Version",
                                 IndicatorType::Position => "Player Position",
+                                IndicatorType::PositionChange => "Player Velocity",
                                 IndicatorType::Igt => "IGT Timer",
                                 IndicatorType::Fps => "FPS",
                                 IndicatorType::FrameCount => "Frame Counter",
@@ -409,6 +415,31 @@ impl PracticeTool {
                                 );
                                 ui.same_line();
                                 ui.text(&self.position_bufs[3]);
+                            }
+                        },
+                        IndicatorType::PositionChange => {
+                            if let Some([x, y, z]) = self.pointers.position.1.read() {
+                                let position_change_xyz = ((x - self.position_prev[0]).powf(2.0)
+                                    + (y - self.position_prev[1]).powf(2.0)
+                                    + (z - self.position_prev[2]).powf(2.0))
+                                .sqrt();
+
+                                let position_change_xz = ((x - self.position_prev[0]).powf(2.0)
+                                    + (z - self.position_prev[2]).powf(2.0))
+                                .sqrt();
+
+                                let position_change_y = y - self.position_prev[1];
+
+                                self.position_change_buf.clear();
+                                write!(
+                                    self.position_change_buf,
+                                    "[XYZ] {position_change_xyz:.6} | [XZ] \
+                                     {position_change_xz:.6} | [Y] {position_change_y:.6}"
+                                )
+                                .ok();
+                                ui.text(&self.position_change_buf);
+
+                                self.position_prev = [x, y, z];
                             }
                         },
                         IndicatorType::Igt => {


### PR DESCRIPTION
This commit adds a velocity indicator, which simply calculates the distance between the character positions from the previous and current frame.

It shows 3 different values:
- [XYZ] Velocity with all 3 coordinates.
- [XZ] Velocity with only the X and Z coordinates, so the Y coordinate (or height) is ignored.
- [Y] Velocity of only the Y coordinate (or height).

The reason for that is that depending on what you want to test, you might not want the Y to be included in the calculation (or want only that one). This is useful for testing on slightly uneven ground or to check the horizontal distance covered when falling or jumping, for example.

I also squeezed in 2 minor tweaks:
- Change the position indicator to show 3 decimal places instead of only 2, for slightly better accuracy.
- Disable a bunch of indicators by default in the config file. This is to restore the default set of enabled indicators from before I added a few. It also matches the hardcoded fallback set now.